### PR TITLE
Implement basic system ordering

### DIFF
--- a/src/host/app.rs
+++ b/src/host/app.rs
@@ -49,7 +49,7 @@ impl HostApp for WasmHost {
 
         for system in systems.iter() {
             let system = table.get_mut(system)?;
-            let boxed_system = system.build(world, mod_name, asset_id, asset_version)?;
+            let schedule_config = system.schedule(world, mod_name, asset_id, asset_version)?;
 
             let schedule = match schedule {
                 Schedule::Update => Update,
@@ -58,7 +58,7 @@ impl HostApp for WasmHost {
             let mut schedules = world
                 .get_resource_mut::<Schedules>()
                 .expect("running in an App");
-            schedules.add_systems(schedule, boxed_system);
+            schedules.add_systems(schedule, schedule_config);
         }
 
         Ok(())

--- a/wit/ecs/ecs.wit
+++ b/wit/ecs/ecs.wit
@@ -38,7 +38,8 @@ interface app {
 	/// Usage:
 	/// 1. Construct a new system, giving it a unique name
 	/// 2. Add system-params by calling 0 or more add-* methods
-	/// 3. Add the system to a schedule
+	/// 3. Order the system relative to others
+	/// 4. Add the system to a schedule
 	resource system {
 		/// Constructs a new system. Use the same name as exported in
 		/// the guest world, otherwise the host won't be able to find it.
@@ -49,6 +50,12 @@ interface app {
 
 		/// Adds a query system-param
 		add-query: func(query: list<query-for>);
+
+		/// Schedules this system be run after another system
+		after: func(other: borrow<system>);
+
+		/// Schedules this system be run before another system
+		before: func(other: borrow<system>);
 	}
 
 	/// A commands system param


### PR DESCRIPTION
So I was going to hold back on adding this feature because I thought it was going to be more difficult to implement. I had no clue how to implement dynamic ordering on boxed systems given they don't really have identifiers, but it turns out bevy uses SystemSets internally as identifiers for systems! So I did the same.